### PR TITLE
Read profile before start

### DIFF
--- a/ApplicationLibrary/Views/Dashboard/StartStopButton.swift
+++ b/ApplicationLibrary/Views/Dashboard/StartStopButton.swift
@@ -77,6 +77,7 @@ public struct StartStopButton: View {
         private nonisolated func switchProfile(_ isEnabled: Bool) async {
             do {
                 if isEnabled {
+                    try await profile.read()
                     try await profile.start()
                     await environments.logClient.connect()
                 } else {


### PR DESCRIPTION
When using **iCloud** profiles, sometime it would report error that could not read the profile. Whenever this happens, I have to go to the profiles page and click `Edit Content`. Then wait for it to spin for a little while, and after the profile is loaded I could go to dashboard and start it. 

By adding this code, I hope to remove this trouble. 

The code is not tested though; I don't have an apple developer account :(