### PR TITLE
Fix:  Sanitize iCloud profile path input

### DIFF
--- a/ApplicationLibrary/Views/Profile/NewProfileView.swift
+++ b/ApplicationLibrary/Views/Profile/NewProfileView.swift
@@ -206,7 +206,10 @@ public struct NewProfileView: View {
             if !FileManager.default.fileExists(atPath: FilePath.iCloudDirectory.path) {
                 try FileManager.default.createDirectory(at: FilePath.iCloudDirectory, withIntermediateDirectories: true)
             }
-            let saveURL = FilePath.iCloudDirectory.appendingPathComponent(remotePath, isDirectory: false)
+
+            // Clean up the remote path
+            let cleanPath = remotePath.replacingOccurrences(of: "../", with: "")
+            let saveURL = FilePath.iCloudDirectory.appendingPathComponent(cleanPath, isDirectory: false)
             _ = saveURL.startAccessingSecurityScopedResource()
             defer {
                 saveURL.stopAccessingSecurityScopedResource()


### PR DESCRIPTION
创建 iCloud 类型配置时，path 参数存在目录穿越BUG：

<img width="500" src="https://github.com/user-attachments/assets/f2971cda-ea13-4acf-b911-b4692e315a8a" />

<img width="500" src="https://github.com/user-attachments/assets/0e5ee28a-6621-4095-a0c3-98157adf6d47" />